### PR TITLE
FIX: cannot handle parameters naming with underscore correctly.

### DIFF
--- a/template/functiontypedef.lua
+++ b/template/functiontypedef.lua
@@ -53,7 +53,7 @@ return [[#
 #         end
 #       end
 #
-#       paramline = paramline .. " " .. param.name ..  " "
+#       paramline = paramline .. " " .. escape(param.name, "_") ..  " "
 #
 #       if param.optional then
 #         paramline = paramline .. "optional" .. " "

--- a/template/page.lua
+++ b/template/page.lua
@@ -17,6 +17,7 @@ return
 #  for _, header in ipairs(_page.headers) do
     $(header)
 #  end
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
   </head>
 #end
 <body>

--- a/template/utils.lua
+++ b/template/utils.lua
@@ -356,7 +356,7 @@ function M.prettyname( apiobject, ... )
   local tag = apiobject.tag
   if M.prettynametypes[tag] then
     local prettyname = M.prettynametypes[tag](apiobject,...)
-    return M.escape(prettyname,'_')
+    return prettyname
   elseif not tag then
     return nil, 'No pretty name available as no tag has been provided.'
   end


### PR DESCRIPTION
luadocumentor cannot handle parameters naming with underscore correctly. e.g. `aaa_bbb_ccc`, `aaa_bbb`

this patch is to fix this problem
